### PR TITLE
Remove UnicodeDecodeError when running sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# VSCode IDE folder
+.vscode

--- a/cadence/langs/english.py
+++ b/cadence/langs/english.py
@@ -127,7 +127,7 @@ def get(token,config={},toprint=False,incl_alt=True):
 def get_cache(source_paths=[CMU_DICT_FN]):
 	if not CACHE:
 		for sfn in source_paths:
-			with open(sfn) as f:
+			with open(sfn, encoding='utf-8') as f:
 				for ln in f:
 					ln=ln.strip()
 					if not ln: continue

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -1,4 +1,24 @@
+
+# Hacky quick-fix allowing importing of cadence module. 
+# Should be removed when this is expanded into a "real" testing suite
+import sys
+sys.path.append("..")
+
 # Sample Test passing with nose and pytest
 
 def test_pass():
     assert True, "dummy sample test"
+
+def test_import():
+    import cadence as cd
+    assert True, "Ensure that Cadence can be imported"
+
+def test_scan():
+    import cadence as cd
+
+    milton = "OF Mans First Disobedience, and the Fruit"\
+    "Of that Forbidden Tree, whose mortal tast"\
+    "Brought Death into the World, and all our woe"
+
+    txtdf = cd.scan(milton)
+    assert txtdf is not None, "Ensure that Cadence can scan without Exceptions"

--- a/tox.ini
+++ b/tox.ini
@@ -2,5 +2,5 @@
 envlist = py27,py34,py35,py36,py37
 
 [testenv]
-commands = py.test cadence
 deps = pytest
+commands = pytest


### PR DESCRIPTION
Hello @quadrismegistus!

So, I did a bit of messing around, trying to get your [example](https://github.com/quadrismegistus/cadence#load-text) to run, but I experienced the following exception:
```python
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 68: character maps to <undefined>
```
at Line 130 in
https://github.com/quadrismegistus/cadence/blob/1fc8fcf4ee471058574b1d4776af93ea5d230058/cadence/langs/english.py#L127-L139

### The issue 
Whenever a file is opened with `open()` in Python, the default system codec will be used, which is OS dependent. On Windows, opening `cmudict.txt` and then proceeding to read it will use an encoding codec that can't read some of the tokens in that file. This is the cause of the exception.

### The fix
You can google the exception and you will see the same fix suggested: specify the encoding to be used. UTF-8 works in most cases. 
This is what I've done in bb6c96fc7f503a582f68fc60e00f3090432fbe64.

### Notes
* This PR contains 4 commits, while only one that actually fixes the issue. If you prefer, just merge bb6c96fc7f503a582f68fc60e00f3090432fbe64. The others are regarding testing and a gitignore addition.
* In particular, commit 9d561219f847ea975a3a20442e148d31dae2c44b modifies the `tox.ini`. I don't know whether you were using it previously, or just took it as a placeholder from another project, but I believe `py.test` is generally considered outdated: https://stackoverflow.com/questions/39495429/py-test-vs-pytest-command/41893170#41893170.
* Speaking of outdated, your `tox.ini` and `setup.py` specify that Python 2.7, 3.4, 3.5, 3.6 and 3.7 are supported. The first three of those have now reached end of life. We have now reached Python 3.8 and Python 3.9. I suspect these first three were never planned to be truly supported either, as (for example) https://github.com/quadrismegistus/cadence/blob/1fc8fcf4ee471058574b1d4776af93ea5d230058/cadence/tools/tools.py#L117-L118 contains f-string formatting, a feature only implemented in Python 3.6 onwards. My recommendation is to remove 2.7, 3.4 and 3.5 from `tox.ini` and `setup.py`, in favor for 3.8 and 3.9. However, these are decisions that you have to make, and I don't mean to step on your toes here.

### How to test
With the commit 9d561219f847ea975a3a20442e148d31dae2c44b I can run `tox` after which `pytest` will be executed on the 5 currently "supported" versions. Sample output is like this:
```python
(.env) PS C:\GitHub\cadence> tox
...
collected 3 items

tests\test_sample.py ...                                                                                                                                                                      [100%]

======================================================================================== 3 passed in 1.33s ========================================================================================= 
_____________________________________________________________________________________________ summary ______________________________________________________________________________________________
ERROR:  py27: InterpreterNotFound: python2.7
ERROR:  py34: InterpreterNotFound: python3.4
ERROR:   py35: commands failed
  py36: commands succeeded
  py37: commands succeeded
```
Note: I don't have Python 2.7 or 3.4, and 3.5 fails because of f-string formatting:
```python
>   from .tools import *
E     File "c:\github\cadence\.tox\py35\lib\site-packages\cadence\tools\tools.py", line 117
E       if not desc: desc=f'Mapping {func.__name__}()'
E                                                    ^
E   SyntaxError: invalid syntax
```

### Also...
Let me know if my work would be appreciated here and there - mostly with fixes or additions. I'm quite busy right now still - just finished up my bachelor thesis, but I would definitely enjoy watching a project grow where I can help in some places.

- Tom Aarsen (Formerly CubieDev on GitHub)